### PR TITLE
Added missing port when connecting to a user-provided IP address

### DIFF
--- a/src/owo_thread.rs
+++ b/src/owo_thread.rs
@@ -35,7 +35,7 @@ pub fn start_owo_thread(
                         if let Some(ip_str) = ip {
                             println!("Connecting to specific IP: {}", ip_str);
                             // Try to connect to the specific IP
-                            client.connect(ip_str);
+                            client.connect((ip_str, 54020));
                         } else {
                             // Use auto-connect if no specific IP is provided
                             client.auto_connect();


### PR DESCRIPTION
<sub>Issue discovered by `@sovereignsays` on the OWO Discord.</sub>

Connecting directly to an IP address fails with the error "invalid socket address".
```
thread '<unnamed>' panicked at %USERPROFILE%\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\owo-skin-rs-1.0.0\src\network.rs:27:14:
Unable to send data: Error { kind: InvalidInput, message: "invalid socket address" }
```

This appears to be the result of a missing port in the call to `connect(add: A)` in `start_owo_thread`.

This PR adds the port `54020` to the call which fixes this error.